### PR TITLE
全操作をログインユーザーにのみ認可

### DIFF
--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -22,10 +22,28 @@ Route::get('/dashboard', function () {
 })->middleware(['auth'])->name('dashboard');
 
 require __DIR__.'/auth.php';
-Route::get('/items', ['App\Http\Controllers\ItemController', 'index'])->name('item.index');
-Route::get('/items/new', ['App\Http\Controllers\ItemController', 'new']);
-Route::post('/items', ['App\Http\Controllers\ItemController', 'create']);
-Route::get('/items/{id}', ['App\Http\Controllers\ItemController', 'show'])->name('item.show');
-Route::get('/items/{id}/edit', ['App\Http\Controllers\ItemController', 'edit'])->name('item.edit');
-Route::put('/items/{id}', ['App\Http\Controllers\ItemController', 'update'])->name('item.update');
-Route::delete('/items/{id}', ['App\Http\Controllers\ItemController', 'destroy'])->name('item.destroy');
+
+Route::get('/items', ['App\Http\Controllers\ItemController', 'index'])
+                ->middleware('auth')
+                ->name('item.index');
+
+Route::get('/items/new', ['App\Http\Controllers\ItemController', 'new'])
+                ->middleware('auth');
+
+Route::post('/items', ['App\Http\Controllers\ItemController', 'create'])
+                ->middleware('auth');
+ 
+Route::get('/items/{id}', ['App\Http\Controllers\ItemController', 'show'])
+                ->middleware('auth')
+                ->name('item.show');
+Route::get('/items/{id}/edit', ['App\Http\Controllers\ItemController', 'edit'])
+                ->middleware('auth')
+                ->name('item.edit');
+
+Route::put('/items/{id}', ['App\Http\Controllers\ItemController', 'update'])
+                ->middleware('auth')
+                ->name('item.update');
+
+Route::delete('/items/{id}', ['App\Http\Controllers\ItemController', 'destroy'])
+                ->middleware('auth')
+                ->name('item.destroy');

--- a/app/tests/Feature/ItemTest.php
+++ b/app/tests/Feature/ItemTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\Item;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
@@ -11,63 +12,130 @@ class ItemTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_items_index_screen_can_be_rendered()
+    public function test_index_screen_can_be_rendered()
+    {   
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->get('/items');
+
+        $response->assertStatus(200);
+    }
+
+    public function test_index_screen_cannot_be_rendered_to_guest_user()
     {
         $response = $this->get('/items');
 
-        $response->assertStatus(200);
+        $response->assertRedirect('/login');
     }
 
-    public function test_items_new_screen_can_be_rendered()
+    public function test_new_screen_can_be_rendered()
+    {   
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->get('/items/new');
+
+        $response->assertStatus(200);
+    }
+    
+    public function test_new_screen_cannot_be_rendered_to_guest_user()
     {
         $response = $this->get('/items/new');
 
-        $response->assertStatus(200);
+        $response->assertRedirect('/login');
     }
 
-    public function test_new_item_can_be_registered()
-    {
-        $response = $this->post('/items',[
+    public function test_item_can_be_registered()
+    {   
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->post('/items',[
             'name' => 'new item',
         ]);
 
         $this->assertDatabaseHas('items',[
             'name' => 'new item'
         ]);
-        $response->assertredirect(route('item.index'));
+        $response->assertRedirect(route('item.index'));
     }
 
-    public function test_item_show_screen_can_be_rendered()
+    public function test_item_cannot_be_registered_by_guest_user()
+    {
+        $response = $this->post('/items',[
+            'name' => 'new item',
+        ]);
+
+        $this->assertDatabaseMissing('items',[
+            'name' => 'new item'
+        ]);
+        $response->assertRedirect('/login');
+    }
+
+    public function test_show_screen_can_be_rendered()
+    {   
+        $user = User::factory()->create();
+        $item = Item::factory()->create();
+        $response = $this->actingAs($user)->get(route('item.show', ['id' => $item->id]));
+
+        $response->assertStatus(200);
+    }
+
+    public function test_show_screen_cannot_be_rendered_to_guest_user()
     {   
         $item = Item::factory()->create();
         $response = $this->get(route('item.show', ['id' => $item->id]));
 
+        $response->assertRedirect('/login');
+    }
+
+    public function test_edit_screen_can_be_rendered()
+    {      
+        $user = User::factory()->create();
+        $item = Item::factory()->create();
+        $response = $this->actingAs($user)->get(route('item.edit', ['id' => $item->id]));
+
         $response->assertStatus(200);
     }
 
-    public function test_item_edit_screen_can_be_rendered()
-    {   
+    public function test_edit_screen_cannot_be_rendered_to_guest_user()
+    {      
         $item = Item::factory()->create();
         $response = $this->get(route('item.edit', ['id' => $item->id]));
 
-        $response->assertStatus(200);
+        $response->assertRedirect('/login');
     }
 
-    public function test_item_name_can_be_changed()
+    public function test_name_can_be_changed()
+    {   
+        $user = User::factory()->create();
+        $item = Item::factory()->create();
+        $response = $this->actingAs($user)->put(route('item.update', ['id' => $item->id, 'name' => 'updated name']));
+
+        $this->assertSame(Item::find($item->id)->name, 'updated name');
+        $response->assertRedirect(route('item.show', ['id' => $item->id]));
+    }   
+
+    public function test_name_cannot_be_changed_by_guest_user()
     {   
         $item = Item::factory()->create();
         $response = $this->put(route('item.update', ['id' => $item->id, 'name' => 'updated name']));
 
-        $this->assertsame(Item::find($item->id)->name, 'updated name');
-        $response->assertredirect(route('item.show', ['id' => $item->id]));
+        $this->assertNotSame(Item::find($item->id)->name, 'updated name');
+        $response->assertRedirect('/login');
     }   
     
     public function test_item_can_be_deleted()
     {   
+        $user = User::factory()->create();
+        $item = Item::factory()->create();
+        $response = $this->actingAs($user)->delete(route('item.destroy', ['id' => $item->id]));
+        
+        $this->assertDatabaseMissing('items', ['id' => $item->id]);
+        $response->assertRedirect(route('item.index'));
+    }   
+
+    public function test_item_cannot_be_deleted_by_guest_user()
+    {   
         $item = Item::factory()->create();
         $response = $this->delete(route('item.destroy', ['id' => $item->id]));
         
-        $this->assertDatabaseMissing('items', ['id' => $item->id]);
-        $response->assertredirect(route('item.index'));
-    }   
+        $this->assertDatabaseHas('items', ['id' => $item->id]);
+        $response->assertRedirect('/login');
+    }
 }


### PR DESCRIPTION
## チケットへのリンク

* http://localhost:80

## やったこと

* 物品に対する操作をログインユーザーのみ認可した。

## やらないこと

* なし

## できるようになること（ユーザ目線）

* なし

## できなくなること（ユーザ目線）

* ログインしていないユーザーは物品ページへのアクセス・追加・編集・削除操作ができない。
* ログインしていないユーザーのリクエストの処理は行わず、/loginへリダイレクトされる。

## 動作確認

* ログインしていない状態でurlにアクセスして挙動を確認した。
* featureテストを追加した。
