### PR TITLE
存在しない物品に対する例外処理

### DIFF
--- a/app/app/Http/Controllers/ItemController.php
+++ b/app/app/Http/Controllers/ItemController.php
@@ -29,12 +29,12 @@ class ItemController extends Controller
     }
 
     public function show($id) {
-        $item = Item::find($id);
+        $item = Item::findOrFail($id);
         return view('item.show', compact('item'));
     }
 
     public function edit($id) {
-        $item = Item::find($id);
+        $item = Item::findOrFail($id);
         if(!$item->isRentable()) {
             return redirect('/items');
         };
@@ -53,7 +53,7 @@ class ItemController extends Controller
 
         Validator::make($merged_params, $rules, [], ['name' => '物品名'])->validate();
 
-        Item::find($id)->update([
+        Item::findOrFail($id)->update([
                         'name' => $request->name
                     ]);
         return redirect()->route('item.show',['id' => $id]);
@@ -66,7 +66,7 @@ class ItemController extends Controller
          
         Validator::make(['id' => $id], $rules)->validate();
 
-        Item::find($id)->delete();
+        Item::findOrFail($id)->delete();
         return redirect('/items');
     }
 }

--- a/app/tests/Feature/Item/ItemTest.php
+++ b/app/tests/Feature/Item/ItemTest.php
@@ -112,7 +112,8 @@ class ItemTest extends TestCase
     public function test_存在しない物品編集画面へのアクセスは404を返す()
     {   
         $user = User::factory()->create();
-        $response = $this->actingAs($user)->get(route('item.edit', ['id' => Item::max('id') + 1]));
+        $non_existent_id = Item::max('id') + 1;
+        $response = $this->actingAs($user)->get(route('item.edit', ['id' => $non_existent_id]));
 
         $response->assertStatus(404);
     }
@@ -139,7 +140,8 @@ class ItemTest extends TestCase
     public function test_存在しない物品の編集は404を返す()
     {   
         $user = User::factory()->create();
-        $response = $this->actingAs($user)->put(route('item.update', ['id' => Item::max('id') + 1, 'name' => 'updated name']));
+        $non_existent_id = Item::max('id') + 1;
+        $response = $this->actingAs($user)->put(route('item.update', ['id' => $non_existent_id, 'name' => 'updated name']));
 
         $response->assertStatus(404);
     }
@@ -166,7 +168,8 @@ class ItemTest extends TestCase
     public function test_存在しない物品の削除は404を返す()
     {   
         $user = User::factory()->create();
-        $response = $this->actingAs($user)->delete(route('item.destroy', ['id' => Item::max('id') + 1]));
+        $non_existent_id = Item::max('id') + 1;
+        $response = $this->actingAs($user)->delete(route('item.destroy', ['id' => $non_existent_id]));
 
         $response->assertStatus(404);
     }

--- a/app/tests/Feature/Item/ItemTest.php
+++ b/app/tests/Feature/Item/ItemTest.php
@@ -84,6 +84,14 @@ class ItemTest extends TestCase
         $response->assertRedirect('/login');
     }
 
+    public function test_存在しない物品詳細画面へのアクセスは404を返す()
+    {   
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->get(route('item.show', ['id' => Item::max('id') + 1]));
+
+        $response->assertStatus(404);
+    }
+
     public function test_edit_screen_can_be_rendered()
     {      
         $user = User::factory()->create();
@@ -99,6 +107,14 @@ class ItemTest extends TestCase
         $response = $this->get(route('item.edit', ['id' => $item->id]));
 
         $response->assertRedirect('/login');
+    }
+
+    public function test_存在しない物品編集画面へのアクセスは404を返す()
+    {   
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->get(route('item.edit', ['id' => Item::max('id') + 1]));
+
+        $response->assertStatus(404);
     }
 
     public function test_name_can_be_changed()
@@ -119,6 +135,14 @@ class ItemTest extends TestCase
         $this->assertNotSame(Item::find($item->id)->name, 'updated name');
         $response->assertRedirect('/login');
     }   
+
+    public function test_存在しない物品の編集は404を返す()
+    {   
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->put(route('item.update', ['id' => Item::max('id') + 1, 'name' => 'updated name']));
+
+        $response->assertStatus(404);
+    }
     
     public function test_item_can_be_deleted()
     {   
@@ -137,5 +161,13 @@ class ItemTest extends TestCase
         
         $this->assertDatabaseHas('items', ['id' => $item->id]);
         $response->assertRedirect('/login');
+    }
+
+    public function test_存在しない物品の削除は404を返す()
+    {   
+        $user = User::factory()->create();
+        $response = $this->actingAs($user)->delete(route('item.destroy', ['id' => Item::max('id') + 1]));
+
+        $response->assertStatus(404);
     }
 }

--- a/app/tests/Feature/Item/ItemTest.php
+++ b/app/tests/Feature/Item/ItemTest.php
@@ -87,7 +87,8 @@ class ItemTest extends TestCase
     public function test_存在しない物品詳細画面へのアクセスは404を返す()
     {   
         $user = User::factory()->create();
-        $response = $this->actingAs($user)->get(route('item.show', ['id' => Item::max('id') + 1]));
+        $non_existent_id = Item::max('id') + 1;
+        $response = $this->actingAs($user)->get(route('item.show', ['id' => $non_existent_id]));
 
         $response->assertStatus(404);
     }


### PR DESCRIPTION
## チケットへのリンク

* http://localhost:80

## やったこと

* 存在しない物品IDへのリクエストに対して例外を出す。404 NOT FOUND画面を表示する。

## やらないこと

* なし

## できるようになること（ユーザ目線）

* 存在しない物品IDのURLにアクセスすると、404 NOT FOUNDの画面が現れる。

## できなくなること（ユーザ目線）

* なし

## 動作確認

* フィーチャーテスト

## その他・レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
* 存在しないIDは、Item::all()->max('id')よりItem::max('id')の方がいいということをさっき知ったので、統一感がないがこちらに書き換えた。