### PR TITLE
Feature/batch command

### DIFF
--- a/app/app/Console/Commands/RegisterRentals.php
+++ b/app/app/Console/Commands/RegisterRentals.php
@@ -46,7 +46,7 @@ class RegisterRentals extends Command
         $target_date = Carbon::today();
         $reservations = Reservation::where('start_date', $target_date)->get();
 
-        foreach($reservations as $reservation) {
+        foreach ($reservations as $reservation) {
             try {
                 DB::beginTransaction();
 
@@ -54,8 +54,7 @@ class RegisterRentals extends Command
                         'user_id' => $reservation->user_id,
                         'item_id' => $reservation->item_id,
                         'end_date' => $reservation->end_date,
-                    ]
-                );
+                    ]);
 
                 Reservation::find($reservation->id)->delete();
 

--- a/app/app/Console/Commands/RegisterRentals.php
+++ b/app/app/Console/Commands/RegisterRentals.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Rental;
+use App\Models\Reservation;
+use Carbon\Carbon;
+use Exception;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class RegisterRentals extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rentals:register';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Register new rentals according to the reservations.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @throws Exception
+     * @return void
+     */
+    public function handle()
+    {
+        $target_date = Carbon::today();
+        $reservations = Reservation::where('start_date', $target_date)->get();
+
+        foreach($reservations as $reservation) {
+            try {
+                DB::beginTransaction();
+
+                Rental::create([
+                        'user_id' => $reservation->user_id,
+                        'item_id' => $reservation->item_id,
+                        'end_date' => $reservation->end_date,
+                    ]
+                );
+
+                Reservation::find($reservation->id)->delete();
+
+                DB::commit();
+            } catch (Exception $e) {
+                DB::rollback();
+            }
+        }
+    }
+}

--- a/app/tests/Feature/Reservation/RegisterRentalBatchTest.php
+++ b/app/tests/Feature/Reservation/RegisterRentalBatchTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Item;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RegisterRentalBatchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $user;
+    protected $another_user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()
+            ->hasAttached(
+                Item::factory()->count(1),
+                [
+                    'start_date' => Carbon::today(),
+                    'end_date' => Carbon::today()->addDay(10),
+                ],
+                'reservations',
+            )
+            ->create();
+
+        $this->another_user = User::factory()
+            ->hasAttached(
+                Item::factory()->count(1),
+                [
+                    'start_date' =>  Carbon::today()->addDay(3),
+                    'end_date' => Carbon::today()->addDay(10),
+                ],
+                'reservations',
+            )
+            ->create();
+    }
+
+    public function test_予約レコードに基づいて貸出が登録される()
+    {
+        $item_id = $this->user->reservations->first()->id;
+        $this->artisan('rentals:register');
+
+        $this->assertDatabaseHas('rentals', [
+            'user_id' => $this->user->id,
+            'item_id' => $item_id,
+            'end_date' => Carbon::today()->addDay(10),
+        ]);
+
+        $this->assertSoftDeleted('reservations', [
+            'user_id' => $this->user->id,
+            'item_id' => $item_id,
+            'start_date' => Carbon::today(),
+            'end_date' => Carbon::today()->addDay(10),
+        ]);
+    }
+
+    public function test_対象日以外の予約は登録されない()
+    {
+        $item_id = $this->another_user->reservations->first()->id;
+        $this->artisan('rentals:register');
+
+        $this->assertDatabaseMissing('rentals', [
+            'user_id' => $this->another_user->id,
+            'item_id' => $item_id,
+            'end_date' => Carbon::today()->addDay(10),
+        ]);
+
+        $this->assertDatabaseHas('reservations', [
+            'user_id' => $this->another_user->id,
+            'item_id' => $item_id,
+            'start_date' => Carbon::today()->addDay(3),
+            'end_date' => Carbon::today()->addDay(10),
+        ]);
+    }
+}


### PR DESCRIPTION
## チケットへのリンク

* http://localhost:80

## やったこと

* 予約を貸出へ返還するコマンドを作成
* `php artisan rentals:register` で、予約情報を貸出に反映させる & 予約を削除する

## やらないこと

* 定期実行のスケジューリング
* スケジューリングはAWS側で行う

## できるようになること（ユーザ目線）

* 予約開始日が来たら自動で貸出処理が行われる

## できなくなること（ユーザ目線）

* なし

## 動作確認

* コマンド実行とDBの目視確認
* フィーチャーテスト

## その他

* app/app/Console/Commands/RegisterRentals.phpのhandleメソッドのレビューをして欲しい（もっと良い書き方あるか？など）
* 貸出テーブルと予約テーブルの整合性を保つため、トランザクションを使ってみました
